### PR TITLE
Publish to bintray

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+This software is licensed under the Apache 2 license, quoted below.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with
+the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
+organization := "io.github"
 name := "crawler"
 
-version := "0.6.0"
-
+crossScalaVersions := Seq("2.11.7", "2.10.5")
+scalaVersion := crossScalaVersions.value.head
 scalacOptions := Seq("-deprecation", "-unchecked", "-feature")
 
 libraryDependencies ++= Seq (
@@ -11,3 +12,8 @@ libraryDependencies ++= Seq (
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
+enablePlugins(GitVersioning)
+git.useGitDescribe := true // figure out version from last tag
+
+// required for release to bintray
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")


### PR DESCRIPTION
Adds required configuration for releasing to bintray. Releasing can be done by creating a tag on a commit and then running `sbt +publish`. When ran first time, `bintray-sbt` will ask for sbt credentials.

After a successful release this library will be able to be used with an additional resovler, for example:

    resolvers += Resolver.bintrayRepo("bplawler", "maven")

PS. Currently `sbt-git` plugin requires at least one tag (https://github.com/sbt/sbt-git/issues/89) for the project to load correctly in sbt when `git.useGitDescribe := true` is used. So after merging this PR, please create one tag and push it so project loads successfully.